### PR TITLE
Added minimum support for HTTPS to FreeInfantry launcher

### DIFF
--- a/Infantry Launcher/Infantry Launcher/Protocol/AccountServer.cs
+++ b/Infantry Launcher/Infantry Launcher/Protocol/AccountServer.cs
@@ -21,6 +21,7 @@ namespace Infantry_Launcher.Protocol
         /// </summary>
         public static IStatus.PingRequestStatusCode PingAccount(string pingUrl)
         {
+            System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
             HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(pingUrl);
             httpWebRequest.Method = "GET";
             httpWebRequest.ContentType = "application/json";
@@ -54,6 +55,7 @@ namespace Infantry_Launcher.Protocol
             if (requestModel == null)
             { throw new ArgumentNullException("requestModel"); }
 
+            System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
             byte[] bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(requestModel));
             HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(RegisterUrl);
             httpWebRequest.Method = "PUT";
@@ -114,6 +116,7 @@ namespace Infantry_Launcher.Protocol
             if (requestModel == null)
             { throw new ArgumentNullException("requestModel"); }
 
+            System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
             byte[] bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(requestModel));
             HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(LoginUrl);
             httpWebRequest.Method = "POST";
@@ -179,6 +182,7 @@ namespace Infantry_Launcher.Protocol
             if (requestModel == null)
             { throw new ArgumentNullException("requestModel"); }
 
+            System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
             byte[] bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(requestModel));
             HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(RequestUrl);
             httpWebRequest.Method = "POST";

--- a/Infantry Launcher/Infantry Launcher/Protocol/AssetDownloader.cs
+++ b/Infantry Launcher/Infantry Launcher/Protocol/AssetDownloader.cs
@@ -72,6 +72,7 @@ namespace Infantry_Launcher.Protocol
                 return;
             }
 
+            System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
             WebClient webClient = new WebClient();
             webClient.DownloadDataCompleted += AssetFileListDownloadCompleted;
 
@@ -222,6 +223,7 @@ namespace Infantry_Launcher.Protocol
             currentAssetDescriptor = asset;
             assetFileName = asset.Name;
 
+            System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
             WebClient webClient = new WebClient();
             webClient.DownloadProgressChanged += new DownloadProgressChangedEventHandler(AssetProgressChanged);
             webClient.DownloadDataCompleted += new DownloadDataCompletedEventHandler(AssetDownloadingComplete);


### PR DESCRIPTION
`System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)192; // Tls - See: https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0`